### PR TITLE
Cleanup & add support for more platforms

### DIFF
--- a/.github/workflows/auto-update-from-base-docker.yml
+++ b/.github/workflows/auto-update-from-base-docker.yml
@@ -5,43 +5,68 @@ on:
     - cron: "23 13 3 * *"
 
 jobs:
-  build:
+  check:
+    name: Base update check
     runs-on: ubuntu-latest
-    env:
-      DOCKER_PLATFORMS: linux/amd64,linux/armhf,linux/arm64
-
+    outputs:
+      needs-updating: ${{ steps.check.outputs.needs-updating }}
     steps:
-      - name: Docker Image Update Checker
-        id: baseupdatecheck
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: master
+      - 
+		name: Check if update available
+        id: check
         uses: lucacome/docker-image-update-checker@v1
         with:
-          base-image: library/alpine:latest
+          base-image: alpine:latest
           image: simeononsecurity/docker-vlmcsd:latest
-      - name: Checkout
+  build:
+    name: Build and publish
+    needs: [check]
+    if: needs.check.outputs.needs-updating == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
         uses: actions/checkout@v3
-        if: steps.check.outputs.needs-updating == 'true'
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.1.0
-        if: steps.check.outputs.needs-updating == 'true'
-      - name: setup docker buildx
-        uses: docker/setup-buildx-action@v2
-        id: buildx
         with:
-          install: true
-        if: steps.check.outputs.needs-updating == 'true'
-      - name: Login to DockerHub
+          ref: master
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            simeononsecurity/docker-vlmcsd
+          flavor: |
+            latest=true
+          tags: |
+            type=schedule,pattern=latest
+      -
+        name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-        if: steps.check.outputs.needs-updating == 'true'
-      - name: Build the Docker image
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes && docker buildx build --platform linux/amd64,linux/armhf,linux/arm64 -t simeononsecurity/docker-vlmcsd:latest --progress=plain --push .
-        if: steps.check.outputs.needs-updating == 'true'
-      - name: Build and push
+          username: simeononsecurity
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+      -
+        name: Build and push
         uses: docker/build-push-action@v4
         with:
-          context: .
+          context: ./
+          platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/arm/v6, linux/386, linux/ppc64le, linux/s390x
           push: true
-          tags: simeononsecurity/docker-vlmcsd:latest
-        if: steps.check.outputs.needs-updating == 'true'
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: |
+            type=registry,ref=simeononsecurity/docker-vlmcsd:buildcache
+          cache-to: |
+            type=registry,ref=simeononsecurity/docker-vlmcsd:buildcache,mode=max

--- a/.github/workflows/auto-update-from-base-docker.yml
+++ b/.github/workflows/auto-update-from-base-docker.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           ref: master
       - 
-		name: Check if update available
+	name: Check if update available
         id: check
         uses: lucacome/docker-image-update-checker@v1
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,42 +3,50 @@ name: Docker Image CI
 on:
   push:
     branches: [master]
+
 jobs:
   build:
+    name: Build and publish
     runs-on: ubuntu-latest
-    env:
-      DOCKER_PLATFORMS: linux/amd64,linux/armhf,linux/arm64
-
     steps:
-      - name: Checkout
+      -
+        name: Checkout
         uses: actions/checkout@v3
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.1.0
-      - name: setup docker buildx
-        uses: docker/setup-buildx-action@v2
-        id: buildx
         with:
-          install: true
-      - name: Login to DockerHub
+          ref: master
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            simeononsecurity/docker-vlmcsd
+          flavor: |
+            latest=true
+          tags: |
+            type=schedule,pattern=latest
+      -
+        name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Build the Docker image
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes && docker buildx build --platform linux/amd64,linux/armhf,linux/arm64 -t simeononsecurity/docker-vlmcsd:latest --progress=plain --push .
-      - name: Build and push
+          username: simeononsecurity
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+      -
+        name: Build and push
         uses: docker/build-push-action@v4
         with:
-          context: .
+          context: ./
+          platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/arm/v6, linux/386
           push: true
-          tags: simeononsecurity/docker-vlmcsd:latest
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.PAT_TOKEN }}
-
-      - name: Build the simeononsecurity/docker-vlmcsd:latest Docker image for Github Registry
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes && docker buildx build --platform linux/amd64,linux/armhf,linux/arm64 -t ghcr.io/simeononsecurity/docker-vlmcsd:latest --progress=plain --push .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: |
+            type=registry,ref=simeononsecurity/docker-vlmcsd:buildcache
+          cache-to: |
+            type=registry,ref=simeononsecurity/docker-vlmcsd:buildcache,mode=max


### PR DESCRIPTION
Previously it was building for only `linux/amd64` platforms. Now it'll build for all platforms that are supported by base image. 
NOTE: Don't forget to add `DOCKERHUB_ACCESS_TOKEN` in Repository secrets